### PR TITLE
Fixed documentation for playlist image uploading

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ await client.playlists.unfollow('id'); // Unfollow a playlist
 await client.playlists.addItems('id', ['spotify:track:id']); // Add items to a playlist
 await client.playlists.reorderItems('id', ['spotify:track:id'], { insertBefore: 10 }) // Reorder the items of the playlist
 await client.playlists.removeItems('id', ['spotify:track:id']); // Remove items of the playlist
-await client.playlists.uploadImage('id', 'data:image/jpeg;base64,/......'); // Upload image to the playlist!
+await client.playlists.uploadImage('id', imageDataUri); // Upload image to the playlist, make sure the URI isn't prepended by 'data:image/jpeg;base64,'
 ```
 
 ## Browse Api

--- a/dist/managers/PlaylistManager.d.ts
+++ b/dist/managers/PlaylistManager.d.ts
@@ -137,7 +137,7 @@ export default class PlaylistManager extends BaseManager {
      *
      * @param id ID of the spotify playlist
      * @param image Image data url of image/jpeg to upload!
-     * @example await client.playlists.uploadImage('id', 'data:image/jpeg;base64,/......');
+     * @example await client.playlists.uploadImage('id', imageDataUri); // Make sure the URI isn't prepended by 'data:image/jpeg;base64,'
      */
     uploadImage(id: string, image: string): Promise<boolean>;
 }

--- a/dist/managers/PlaylistManager.js
+++ b/dist/managers/PlaylistManager.js
@@ -294,7 +294,7 @@ class PlaylistManager extends BaseManager_1.default {
      *
      * @param id ID of the spotify playlist
      * @param image Image data url of image/jpeg to upload!
-     * @example await client.playlists.uploadImage('id', 'data:image/jpeg;base64,/......');
+     * @example await client.playlists.uploadImage('id', imageDataUri); // Make sure the URI isn't prepended by 'data:image/jpeg;base64,'
      */
     async uploadImage(id, image) {
         try {

--- a/dist/structures/Playlist.d.ts
+++ b/dist/structures/Playlist.d.ts
@@ -149,7 +149,7 @@ export default class Playlist {
      * Upload a custom image to the playlist!
      *
      * @param image Image data url of image/jpeg to upload!
-     * @example await playlist.uploadImage('data:image/jpeg;base64,/......');
+     * @example await client.playlists.uploadImage('id', imageDataUri); // Make sure the URI isn't prepended by 'data:image/jpeg;base64,'
      */
     uploadImage(image: string): Promise<boolean>;
 }

--- a/dist/structures/Playlist.js
+++ b/dist/structures/Playlist.js
@@ -202,7 +202,7 @@ class Playlist {
      * Upload a custom image to the playlist!
      *
      * @param image Image data url of image/jpeg to upload!
-     * @example await playlist.uploadImage('data:image/jpeg;base64,/......');
+     * @example await client.playlists.uploadImage('id', imageDataUri); // Make sure the URI isn't prepended by 'data:image/jpeg;base64,'
      */
     async uploadImage(image) {
         return await this.client.playlists.uploadImage(this.id, image);

--- a/src/managers/PlaylistManager.ts
+++ b/src/managers/PlaylistManager.ts
@@ -310,7 +310,7 @@ export default class PlaylistManager extends BaseManager{
      * 
      * @param id ID of the spotify playlist
      * @param image Image data url of image/jpeg to upload!
-     * @example await client.playlists.uploadImage('id', 'data:image/jpeg;base64,/......');
+     * @example await client.playlists.uploadImage('id', imageDataUri); // Make sure the URI isn't prepended by 'data:image/jpeg;base64,'
      */
     async uploadImage(id: string, image: string): Promise<boolean> {
 

--- a/src/structures/Playlist.ts
+++ b/src/structures/Playlist.ts
@@ -245,7 +245,7 @@ export function PlaylistTrack(data, client: Client): PlaylistTrackType {
      * Upload a custom image to the playlist!
      * 
      * @param image Image data url of image/jpeg to upload!
-     * @example await playlist.uploadImage('data:image/jpeg;base64,/......');
+     * @example await client.playlists.uploadImage('id', imageDataUri); // Make sure the URI isn't prepended by 'data:image/jpeg;base64,'
      */
     async uploadImage(image: string): Promise<boolean> {
         return await this.client.playlists.uploadImage(this.id, image);


### PR DESCRIPTION
The documentation for uploading playlist images doesn't mention that you need to remove the prepended URI metadata, this fixes that.