### PR TITLE
Fixed playlists always being created public

### DIFF
--- a/dist/UserClient.js
+++ b/dist/UserClient.js
@@ -120,7 +120,7 @@ class UserClient {
                     "Content-Type": "application/json"
                 },
                 body: {
-                    public: options.public || true
+                    public: options.public ?? true
                 }
             });
             return true;
@@ -201,7 +201,7 @@ class UserClient {
                 },
                 body: {
                     name: options.name,
-                    public: options.public || true,
+                    public: options.public ?? true,
                     collaborative: options.collaborative || false,
                     description: options.description || ''
                 }

--- a/dist/structures/Playlist.js
+++ b/dist/structures/Playlist.js
@@ -151,7 +151,7 @@ class Playlist {
     async edit(options) {
         const opts = {
             name: this.name,
-            public: this.public || true,
+            public: this.public ?? true,
             collaborative: this.collaborative,
             description: this.description
         };

--- a/src/UserClient.ts
+++ b/src/UserClient.ts
@@ -265,7 +265,7 @@ export default class UserClient{
                 },
                 body: {
                     name: options.name,
-                    public: options.public || true,
+                    public: options.public ?? true,
                     collaborative: options.collaborative || false,
                     description: options.description || ''
                 }

--- a/src/structures/Playlist.ts
+++ b/src/structures/Playlist.ts
@@ -189,7 +189,7 @@ export function PlaylistTrack(data, client: Client): PlaylistTrackType {
     async edit(options?: Omit<CreatePlaylist, 'userID'>): Promise<this | false> {
         const opts: Required<Omit<CreatePlaylist, 'userID'>> = {
             name: this.name,
-            public: this.public || true,
+            public: this.public ?? true,
             collaborative: this.collaborative,
             description: this.description
         }


### PR DESCRIPTION
When creating playlists, I noticed my `public` option was always being overridden. I think the cause is this pattern:

```
options.public || true
```

which seems like it would just always evaluate to `true`. I've swapped it for the [?? operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator).