### PR TITLE
Fix spelling in reorderItems for uris parameter

### DIFF
--- a/src/managers/Playlist.ts
+++ b/src/managers/Playlist.ts
@@ -130,7 +130,7 @@ export class PlaylistManager {
         const fetchedData = await this.client.fetch(`/playlists/${id}/tracks`, {
             method: 'PUT',
             body: {
-                ...(options.uris !== undefined && { uri: options.uris }),
+                ...(options.uris !== undefined && { uris: options.uris }),
                 ...(options.rangeStart !== undefined && { range_start: options.rangeStart }),
                 ...(options.rangeLength !== undefined && { range_length: options.rangeLength }),
                 ...(options.insertBefore !== undefined && { insert_before: options.insertBefore }),


### PR DESCRIPTION
## Changes

<!-- Describe what changes this pull request includes and explain why are they need to be added? -->
Adjusts the spelling of the `uris` parameter in the `reorderItems` function to be correct again. ([see Spotify Web API documentation](https://developer.spotify.com/documentation/web-api/reference/#/operations/reorder-or-replace-playlists-tracks))

Fixes #157

## Status

- [x] These changes have been tested and documented properly.
- [ ] This pull request introduces some breaking changes.