### PR TITLE
Fix README typo in code for Rate Limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Ratelimits are common with any api services to prevent spam but sometimes it mig
 const Spotify = require("spotify-api.js");
 const client = new Spotify.Client({ 
     token: 'token',
-    retryOnCacheLimit: true
+    retryOnRateLimit: true
 });
 
 console.log(await client.tracks.get('id'));


### PR DESCRIPTION
The sample code in the README showed `retryOnCacheLimit`, when it should be `retryOnRateLimit`

## Changes

Simple README typo fix.

## Status

- [✓] These changes have been tested and documented properly.
- [ ] This pull request introduces some breaking changes.