### PR TITLE
Properly reject the promise in client initialisation

### DIFF
--- a/src/Interface.ts
+++ b/src/Interface.ts
@@ -40,6 +40,8 @@ export type CamelCaseObjectKeys<T> = {
 export interface ClientOptions {
     /** The ready event which is called when the token is aquired. */
     onReady?: (client: Client) => void;
+    /** The fail event which is called when something wrong happens in the client initialisation. */
+    onFail?: (error) => void;
     /** The refresh which is called when there is a token refresh. */
     onRefresh?: () => void;
     /** Set true to refresh token if the token is needed to be acquired if expired by default it is false. */


### PR DESCRIPTION
## Changes

In case of an authentication error or an API outage during client initialisation, it's not possible to catch the error.

## Status

- [X] These changes have been tested and documented properly.
- [X] This pull request introduces some breaking changes.