### PR TITLE
Add a parameter to getPlaylists to fetch all playlists at once

### DIFF
--- a/src/managers/UserClient.ts
+++ b/src/managers/UserClient.ts
@@ -6,6 +6,7 @@ import type { Track } from "../structures/Track";
 import type { Episode } from "../structures/Episode";
 import type { Show } from "../structures/Show";
 import type { Album } from "../structures/Album";
+import type {PlaylistList} from "../structures/PlaylistList";
 import { Player } from "./Player";
 import { SpotifyAPIError } from "../Error";
 import { createCacheStructArray, createCacheSavedStructArray } from "../Cache";
@@ -127,18 +128,30 @@ export class UserClient {
 
     /**
      * Get the list of playlists of the current user.
-     * 
+     *
      * @param options The limit, offset query parameter options.
+     * @param fetchAll Retrieve all playlist at once if more than 50
      * @example const playlists = await client.user.getPlaylists();
      */
     public async getPlaylists(
         options: {
             limit?: number,
             offset?: number
-        } = {}
+        } = {},
+        fetchAll: boolean = false
     ): Promise<Playlist[]> {
-        const fetchedData = await this.client.fetch(`/me/playlists`, { params: options });
-        return fetchedData ? createCacheStructArray('playlists', this.client, fetchedData.items) : [];
+        const fetchedData: PlaylistList = await this.client.fetch(`/me/playlists`, { params: options });
+        let playlists: Array<Playlist> = fetchedData.items
+        const initialFetchedItemsCount = playlists.length
+
+        if (fetchAll && fetchedData.total > initialFetchedItemsCount) {
+            for (let offset = initialFetchedItemsCount; offset < fetchedData.total; offset += initialFetchedItemsCount) {
+                const playListBatch: PlaylistList = await this.client.fetch(`/me/playlists`, { params: {limit: initialFetchedItemsCount, offset} });
+                playlists.push(...playListBatch.items);
+            }
+        }
+
+        return fetchedData ? createCacheStructArray('playlists', this.client, playlists) : [];
     }
 
     /**

--- a/src/structures/PlaylistList.ts
+++ b/src/structures/PlaylistList.ts
@@ -1,0 +1,57 @@
+import type { Client } from "../Client";
+import {Playlist} from "./Playlist";
+
+/**
+ * Spotify api's playlist object.
+ */
+export class PlaylistList {
+    /**
+     * A link to the Web API endpoint returning the full result of the request.
+     */
+    public href: string;
+
+    /**
+     * URL to the next page of items. ( null if none).
+     */
+    public next?: string;
+
+    /**
+     * URL to the previous page of items. ( null if none).
+     */
+    public previous?: string;
+
+    /**
+     *  A list of Playlist.
+     */
+    public items: Playlist[];
+
+    /**
+     * The maximum number of items in the response (as set in the query or by default).
+     */
+    public limit: number;
+
+    /**
+     * The offset of the items returned (as set in the query or by default).
+     */
+    public offset: number;
+
+    /**
+     * The total number of items available to return.
+     */
+    public total: number;
+
+    /**
+     * @param data The raw data received from the api.
+     * @param client The spotify client.
+     * @example const playlistList = new PlaylistList(fetchedData, client);
+     */
+    public constructor(data: any, client: Client) {
+        this.href = data.href;
+        this.next = data.next;
+        this.previous = data.previous;
+        this.items = data.items;
+        this.limit = data.limit;
+        this.offset = data.offset;
+        this.total = data.total;
+    }
+}


### PR DESCRIPTION
## Changes

Add a parameter to getPlaylists to fetch all playlists at once.
This logic is maybe a little out of scope of this library but it's impossible for a program calling getPlaylists to know the playlist count of an user.
The data returned from getPlaylists is only an array of playlists. The response from the API containing the total, the url, etc (https://developer.spotify.com/documentation/web-api/reference/#/operations/get-list-users-playlists) is not exposed directly to the user.

I didn't add a type because PlaylistList is internal only.

## Status

- [X] These changes have been tested and documented properly.
- [X] This pull request introduces some breaking changes.