### PR TITLE
handle `The access token expired` api error and refresh token

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -206,9 +206,9 @@ export class Client {
                 if (typeof retryAfter == "number") await new Promise(r => setTimeout(r, retryAfter * 1000));
             } else if (
                 // @ts-ignore
-                error.response.data.error.message == "Invalid access token" ||
+                error.response.data?.error?.message == "Invalid access token" ||
                 // @ts-ignore
-                error.response.data.error.message == "The access token expired" &&
+                error.response.data?.error?.message == "The access token expired" &&
                 this.refreshMeta
             ) await this.refreshFromMeta();
             else throw new SpotifyAPIError(error);

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -204,8 +204,13 @@ export class Client {
             else if (error.response.status == 429 && this.retryOnRateLimit) {
                 const retryAfter = error.response.headers['Retry-After'];
                 if (typeof retryAfter == "number") await new Promise(r => setTimeout(r, retryAfter * 1000));
-            // @ts-ignore
-            } else if (error.response.data.error.message == "Invalid access token" && this.refreshMeta) await this.refreshFromMeta();
+            } else if (
+                // @ts-ignore
+                error.response.data.error.message == "Invalid access token" ||
+                // @ts-ignore
+                error.response.data.error.message == "The access token expired" &&
+                this.refreshMeta
+            ) await this.refreshFromMeta();
             else throw new SpotifyAPIError(error);
 
             return this.fetch(url, options);


### PR DESCRIPTION
## Changes

match error message `the access token expired` from the spotify api and perform `Client.refreshFromMeta()`

## Status

- [x] These changes have been tested and documented properly.
- [ ] This pull request introduces some breaking changes.