### PR TITLE
fix(auth): ensure to set proper "Content-Type" HTTP request header

### DIFF
--- a/src/managers/Auth.ts
+++ b/src/managers/Auth.ts
@@ -39,6 +39,7 @@ export class AuthManager {
 			headers: {
 				"Content-Type": "application/x-www-form-urlencoded",
 			},
+			data: {},
 		});
 
 		return data.access_token;
@@ -78,6 +79,7 @@ export class AuthManager {
 				"Content-Type": "application/x-www-form-urlencoded",
 				Authorization: `Basic ${encodeBase64(options.clientID + ":" + options.clientSecret)}`,
 			},
+			data: {},
 		});
 
 		return {


### PR DESCRIPTION
When not specifying a "data" property for HTTP requests, Axios uses a "Content-Type: application/json" header, even if another "Content-Type" header was specified. This makes these requests to the Spotify API fail with a response status of 400 and a response body of

	{"error":"server_error"}

This change sets an empty "data" property to make Axios send the "Content-Type: application/x-www-form-urlencoded" header as expected.

I spent quite a bit of time on debugging this, until I found https://github.com/spotify/web-api/issues/449#issuecomment-312677019