### PR TITLE
fix(playlist): fix request body field name to remove playlist items

### DIFF
--- a/src/managers/Playlist.ts
+++ b/src/managers/Playlist.ts
@@ -159,7 +159,7 @@ export class PlaylistManager {
 		const body = {} as any;
 
 		if (snapshotID) body.snapshot_id = snapshotID;
-		if (uris) body.uris = uris.map(uri => ({ uri }));
+		if (uris) body.tracks = uris.map(uri => ({ uri }));
 
 		const fetchedData = await this.client.fetch(`/playlists/${id}/tracks`, {
 			method: "DELETE",


### PR DESCRIPTION
The URIs field is called "tracks", not "uris".
See https://developer.spotify.com/documentation/web-api/reference/remove-tracks-playlist

Fixes https://github.com/spotify-api/spotify-api.js/issues/241.